### PR TITLE
Using standard Swagger behavior for required if array is present,

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -107,12 +107,12 @@ var getViewForSwagger2 = function(opts, type){
                 // extract parameter type
                 _.merge(parameter, typeConversion.convertType(parameter));
 
-                _.each(parameter.properties, function(property) {
-                    if ( parameter.required ) {
-                        property.isRequired = parameter.required[property.name];
+                if ( parameter.required ) {
+                    _.each(parameter.properties, function (property) {
+                        property.isRequired = !!parameter.required[property.name];
                         property.isOptional = !property.isRequired;
-                    }
-                });
+                    });
+                }
 
                 method.parameters.push(parameter);
             });
@@ -147,10 +147,9 @@ var getViewForSwagger2 = function(opts, type){
         var tsType = typeConversion.convertType(swaggerType);
         tsType.name = name;
 
-        if ( swaggerType.required ) { // overrides
+        if ( swaggerType.required ) {
             _.each(tsType.properties, function(property) {
-                // a property is considered required if the property itself or its containing type assert it is
-                property.isRequired = property.isRequired || _.contains(swaggerType.required, property.name);
+                property.isRequired = !!_.contains(swaggerType.required, property.name);
                 property.isOptional = !property.isRequired;
             });
         }


### PR DESCRIPTION
otherwise falling back to backward compatible behavior of assuming
that any listed property is required.